### PR TITLE
✨ (new module) adds map math functions

### DIFF
--- a/_index.scss
+++ b/_index.scss
@@ -5,3 +5,4 @@
 @forward 'proportional-text/index';
 @forward 'spacing/index';
 @forward 'card-pattern/index';
+@forward 'map-math/index';

--- a/map-math/_functions.scss
+++ b/map-math/_functions.scss
@@ -1,0 +1,143 @@
+@function map-multiply($value1, $value2, $calc: false) {
+    @if (meta.type-of($value1) == 'map') {
+        @return map-multiply-responsive($value1, $value1, $value2, $calc);
+    } @else if (meta.type-of($value2) == 'map') {
+        @return map-multiply-responsive($value2, $value1, $value2, $calc);
+    } @else {
+        @if $calc {
+            @return calc(#{$value1} * #{$value2});
+        }
+        @return $value1 * $value2;
+    }
+}
+
+@function map-multiply-responsive($sizes, $value1, $value2, $calc: false) {
+    $map: ();
+
+    @each $breakpoint, $size in $sizes {
+        $bp-value1: $value1;
+        @if (meta.type-of($value1) == 'map') {
+            $bp-value1: map.get($value1, $breakpoint)
+        }
+
+        $bp-value2: $value2;
+        @if (meta.type-of($value2) == 'map') {
+            $bp-value2: map.get($value2, $breakpoint)
+        }
+        @if $calc {
+            $map: map.set($map, $breakpoint, calc(#{$bp-value1} * #{$bp-value2}));
+        } @else {
+            $map: map.set($map, $breakpoint, $bp-value1 * $bp-value2);
+        }
+    }
+
+    @return $map;
+}
+
+@function map-divide($value1, $value2, $calc: false) {
+    @if (meta.type-of($value1) == 'map') {
+        @return map-divide-responsive($value1, $value1, $value2, $calc);
+    } @else if (meta.type-of($value2) == 'map') {
+        @return map-divide-responsive($value2, $value1, $value2, $calc);
+    } @else {
+        @if $calc {
+            @return calc(#{$value1} / #{$value2});
+        }
+        @return $value1 / $value2;
+    }
+}
+
+@function map-divide-responsive($sizes, $value1, $value2, $calc: false) {
+    $map: ();
+
+    @each $breakpoint, $size in $sizes {
+        $bp-value1: $value1;
+        @if (meta.type-of($value1) == 'map') {
+            $bp-value1: map.get($value1, $breakpoint)
+        }
+
+        $bp-value2: $value2;
+        @if (meta.type-of($value2) == 'map') {
+            $bp-value2: map.get($value2, $breakpoint)
+        }
+        @if $calc {
+            $map: map.set($map, $breakpoint, calc(#{$bp-value1} / #{$bp-value2}));
+        } @else {
+            $map: map.set($map, $breakpoint, $bp-value1 / $bp-value2);
+        }
+    }
+
+    @return $map;
+}
+
+@function map-add($value1, $value2, $calc: false) {
+    @if (meta.type-of($value1) == 'map') {
+        @return map-add-responsive($value1, $value1, $value2, $calc);
+    } @else if (meta.type-of($value2) == 'map') {
+        @return map-add-responsive($value2, $value1, $value2, $calc);
+    } @else {
+        @if $calc {
+            @return calc(#{$value1} + #{$value2});
+        }
+        @return $value1 + $value2;
+    }
+}
+
+@function map-add-responsive($sizes, $value1, $value2, $calc: false) {
+    $map: ();
+
+    @each $breakpoint, $size in $sizes {
+        $bp-value1: $value1;
+        @if (meta.type-of($value1) == 'map') {
+            $bp-value1: map.get($value1, $breakpoint)
+        }
+
+        $bp-value2: $value2;
+        @if (meta.type-of($value2) == 'map') {
+            $bp-value2: map.get($value2, $breakpoint)
+        }
+        @if $calc {
+            $map: map.set($map, $breakpoint, calc(#{$bp-value1} + #{$bp-value2}));
+        } @else {
+            $map: map.set($map, $breakpoint, $bp-value1 + $bp-value2);
+        }
+    }
+
+    @return $map;
+}
+
+@function map-subtract($value1, $value2, $calc: false) {
+    @if (meta.type-of($value1) == 'map') {
+        @return map-subtract-responsive($value1, $value1, $value2, $calc);
+    } @else if (meta.type-of($value2) == 'map') {
+        @return map-subtract-responsive($value2, $value1, $value2, $calc);
+    } @else {
+        @if $calc {
+            @return calc(#{$value1} - #{$value2});
+        }
+        @return $value1 - $value2;
+    }
+}
+
+@function map-subtract-responsive($sizes, $value1, $value2, $calc: false) {
+    $map: ();
+
+    @each $breakpoint, $size in $sizes {
+        $bp-value1: $value1;
+        @if (meta.type-of($value1) == 'map') {
+            $bp-value1: map.get($value1, $breakpoint)
+        }
+
+        $bp-value2: $value2;
+        @if (meta.type-of($value2) == 'map') {
+            $bp-value2: map.get($value2, $breakpoint)
+        }
+        @if $calc {
+            $map: map.set($map, $breakpoint, calc(#{$bp-value1} - #{$bp-value2}));
+        } @else {
+            $map: map.set($map, $breakpoint, $bp-value1 - $bp-value2);
+        }
+    }
+
+    @return $map;
+}

--- a/map-math/_index.scss
+++ b/map-math/_index.scss
@@ -1,0 +1,1 @@
+@forward 'functions';

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "peerDependencies": {
     "fibers": "^5.0.0",
-    "sass": "^1.26.10"
+    "sass": "^1.32.0",
+    "sass-loader": "^10.1.0"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1369,6 +1369,21 @@ chalk@^2.0.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+"chokidar@>=2.0.0 <4.0.0":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
+  integrity sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -3006,6 +3021,13 @@ readdirp@~3.4.0:
   dependencies:
     picomatch "^2.2.1"
 
+readdirp@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  dependencies:
+    picomatch "^2.2.1"
+
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz#e5de7111d655e7ba60c057dbe9ff37c87e65cdec"
@@ -3167,6 +3189,13 @@ sass-rem@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/sass-rem/-/sass-rem-2.0.1.tgz#dd863ec9ca5e0597eae5dd239f1f00a6c0f729b0"
   integrity sha512-Fuf7i1Wr7n1lIdCiImhCJ1/S0jEYq1OmrlqyKuJKSU2B2kHbU09HJIo5AuADvbf3DJLlRxU7b8Jm8D6m5lfqmA==
+
+sass@^1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.0.tgz#10101a026c13080b14e2b374d4e15ee24400a4d3"
+  integrity sha512-fhyqEbMIycQA4blrz/C0pYhv2o4x2y6FYYAH0CshBw3DXh5D5wyERgxw0ptdau1orc/GhNrhF7DFN2etyOCEng==
+  dependencies:
+    chokidar ">=2.0.0 <4.0.0"
 
 schema-utils@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## DO NOT MERGE UNTIL THE FOLLOWING IS RESOLVED

These functions only run in the latest versions of sass, and sass-loader which support map.set.

As this project is pre-release I have pushed breaking changes with minor version bumps, but projects using this library may not have their npm dependencies correctly configured and may inadvertently pull in a new minor version of this project.

Merge and version bump should be accompanied by asking everyone to either restrict their package.json to only update patch versions (~ instead of ^) or to update to latest sass and sass-loader.